### PR TITLE
Fix build error due to inaccessible member

### DIFF
--- a/src/MapsApp.Shared/ViewModels/GeocodeViewModel.cs
+++ b/src/MapsApp.Shared/ViewModels/GeocodeViewModel.cs
@@ -324,7 +324,7 @@ namespace Esri.ArcGISRuntime.ExampleApps.MapsApp.ViewModels
         /// Use the locator to perform a reverse geocode operation, returning the place that the user tapped on inside the map
         /// If the user's current location is passed, then set that as the FromPlace used for routing instead
         /// </summary>
-        private async Task<GeocodeResult> GetReverseGeocodedLocationAsync(MapPoint location)
+        internal async Task<GeocodeResult> GetReverseGeocodedLocationAsync(MapPoint location)
         {
             try
             {


### PR DESCRIPTION
Changes accessiblity of `GeocodeViewModel.GetReverseGeocodedLocationAsync` to fix build.  Needs to be `internal` due to references [here](https://github.com/Esri/maps-app-dotnet/blob/272cac8923d1f743ac0fbeb084f74c725fe9cb6a/src/MapsApp.Xamarin.Shared/Views/StartPage.xaml.cs#L328) and [here](https://github.com/Esri/maps-app-dotnet/blob/272cac8923d1f743ac0fbeb084f74c725fe9cb6a/src/MapsApp.WPF/MainWindow.xaml.cs#L214).