### PR TITLE
Update iOS minimum to 13, improve iOS 14 compatibility

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 ## 1.0.9
 
 - Removes support for iOS 12.
+- Updates Xamarin.Forms to add support for iOS 14.
 
 ## 1.0.8
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## 1.0.9
+
+- Removes support for iOS 12.
+
 ## 1.0.8
 
 - Improves app configuration and setup instructions for clarity.

--- a/src/MapsApp.Android/MapsApp.Android.csproj
+++ b/src/MapsApp.Android/MapsApp.Android.csproj
@@ -203,7 +203,7 @@
       <Version>1.7.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.8.0.1364</Version>
+      <Version>4.8.0.1687</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MapsApp.Android/MapsApp.Android.csproj
+++ b/src/MapsApp.Android/MapsApp.Android.csproj
@@ -24,7 +24,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
-    <ReleaseVersion>1.0.8</ReleaseVersion>
+    <ReleaseVersion>1.0.9</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/MapsApp.Android/Properties/AssemblyInfo.cs
+++ b/src/MapsApp.Android/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.8.0")]
-[assembly: AssemblyFileVersion("1.0.8.0")]
+[assembly: AssemblyVersion("1.0.9.0")]
+[assembly: AssemblyFileVersion("1.0.9.0")]
 
 // Add some common permissions, these can be removed if not needed
 [assembly: UsesPermission(Android.Manifest.Permission.Internet)]

--- a/src/MapsApp.Shared/MapsApp.Shared.shproj
+++ b/src/MapsApp.Shared/MapsApp.Shared.shproj
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>2c2a9421-c9c7-4a51-aae3-216f7e05d8d8</ProjectGuid>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
-    <ReleaseVersion>1.0.8</ReleaseVersion>
+    <ReleaseVersion>1.0.9</ReleaseVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />

--- a/src/MapsApp.UWP/MapsApp.UWP.csproj
+++ b/src/MapsApp.UWP/MapsApp.UWP.csproj
@@ -264,7 +264,7 @@
       <Version>1.7.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.8.0.1364</Version>
+      <Version>4.8.0.1687</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/src/MapsApp.UWP/MapsApp.UWP.csproj
+++ b/src/MapsApp.UWP/MapsApp.UWP.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>MapsApp</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/src/MapsApp.UWP/MapsApp.UWP.csproj
+++ b/src/MapsApp.UWP/MapsApp.UWP.csproj
@@ -24,7 +24,7 @@
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <RuntimeIdentifiers>win10-arm;win10-arm-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot</RuntimeIdentifiers>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
-    <ReleaseVersion>1.0.8</ReleaseVersion>
+    <ReleaseVersion>1.0.9</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/MapsApp.UWP/Package.appxmanifest
+++ b/src/MapsApp.UWP/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="35983211-96d8-4e7f-aecc-7bead6ca0d16" Publisher="CN=esri" Version="1.0.8.0" />
+  <Identity Name="35983211-96d8-4e7f-aecc-7bead6ca0d16" Publisher="CN=esri" Version="1.0.9.0" />
   <mp:PhoneIdentity PhoneProductId="f736c883-f105-4d30-a719-4bf328872f5e" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>MapsApp.UWP</DisplayName>

--- a/src/MapsApp.UWP/Properties/AssemblyInfo.cs
+++ b/src/MapsApp.UWP/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.8.0")]
-[assembly: AssemblyFileVersion("1.0.8.0")]
+[assembly: AssemblyVersion("1.0.9.0")]
+[assembly: AssemblyFileVersion("1.0.9.0")]
 [assembly: ComVisible(false)]

--- a/src/MapsApp.WPF_NetCore/MapsApp.WPF_NetCore.csproj
+++ b/src/MapsApp.WPF_NetCore/MapsApp.WPF_NetCore.csproj
@@ -9,7 +9,7 @@
     <DefineConstants>WPF;NET_CORE</DefineConstants>
     <DefaultItemExcludes>$(DefaultItemExcludes);netframework\**;obj\**;netcore\**;out\**;bin\**</DefaultItemExcludes>
     <ApplicationIcon>..\MapsApp.WPF_NetFramework\Images\ArcGIS_Open_Source_Apps.ico</ApplicationIcon>
-    <ReleaseVersion>1.0.8</ReleaseVersion>
+    <ReleaseVersion>1.0.9</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MapsApp.WPF_NetFramework/MapsApp.WPF_NetFramework.csproj
+++ b/src/MapsApp.WPF_NetFramework/MapsApp.WPF_NetFramework.csproj
@@ -27,11 +27,11 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.8.0</ApplicationVersion>
+    <ApplicationVersion>1.0.9.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
-    <ReleaseVersion>1.0.8</ReleaseVersion>
+    <ReleaseVersion>1.0.9</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/MapsApp.WPF_NetFramework/Properties/AssemblyInfo.cs
+++ b/src/MapsApp.WPF_NetFramework/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.8.0")]
-[assembly: AssemblyFileVersion("1.0.8.0")]
+[assembly: AssemblyVersion("1.0.9.0")]
+[assembly: AssemblyFileVersion("1.0.9.0")]

--- a/src/MapsApp.Xamarin.Shared/MapsApp.Xamarin.Shared.shproj
+++ b/src/MapsApp.Xamarin.Shared/MapsApp.Xamarin.Shared.shproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>c0e5c9c0-53d2-4eed-b36e-d7a8db55e1d1</ProjectGuid>
-    <ReleaseVersion>1.0.8</ReleaseVersion>
+    <ReleaseVersion>1.0.9</ReleaseVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />

--- a/src/MapsApp.iOS/Info.plist
+++ b/src/MapsApp.iOS/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.esri.arcgisruntime.opensourceapps.maps-app-xamarin</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.8</string>
+	<string>1.0.9</string>
 	<key>CFBundleIconFiles</key>
 	<array>
 		<string>Icon-60@2x.png</string>
@@ -75,6 +75,6 @@
 	<key>CFBundleName</key>
 	<string>MapsApp</string>
 	<key>MinimumOSVersion</key>
-	<string>12.0</string>
+	<string>13.0</string>
 </dict>
 </plist>

--- a/src/MapsApp.iOS/MapsApp.iOS.csproj
+++ b/src/MapsApp.iOS/MapsApp.iOS.csproj
@@ -26,11 +26,11 @@
     <MapFileExtensions>true</MapFileExtensions>
     <AutorunEnabled>true</AutorunEnabled>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.8.0</ApplicationVersion>
+    <ApplicationVersion>1.0.9.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <ReleaseVersion>1.0.8</ReleaseVersion>
+    <ReleaseVersion>1.0.9</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/MapsApp.iOS/MapsApp.iOS.csproj
+++ b/src/MapsApp.iOS/MapsApp.iOS.csproj
@@ -537,7 +537,7 @@
       <Version>1.7.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.8.0.1364</Version>
+      <Version>4.8.0.1687</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MapsApp.iOS/Properties/AssemblyInfo.cs
+++ b/src/MapsApp.iOS/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using Xamarin.Forms.Xaml;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.8.0")]
-[assembly: AssemblyFileVersion("1.0.8.0")]
+[assembly: AssemblyVersion("1.0.9.0")]
+[assembly: AssemblyFileVersion("1.0.9.0")]
 
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]

--- a/src/MapsApp.sln
+++ b/src/MapsApp.sln
@@ -328,6 +328,6 @@ Global
 		SolutionGuid = {85B96781-BD01-489E-9F9F-91FFECC94A17}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 1.0.8
+		version = 1.0.9
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
With 100.10, iOS 12 will be deprecated. This change removes support for iOS 12 for the dev branch. RT will be updated to 100.10 in a future PR ahead of certification.

Xamarin.Forms is updated to the latest stable. This fixes a layout issue on iPhone 12 mini running iOS 14.